### PR TITLE
Fix incorrect timestamps in session ZIP metadata

### DIFF
--- a/backend/app/utils/zip_generator.py
+++ b/backend/app/utils/zip_generator.py
@@ -2,10 +2,8 @@ import io
 import zipfile
 import requests
 from typing import List, Dict
-import asyncio
 from concurrent.futures import ThreadPoolExecutor
-import tempfile
-import os
+from datetime import datetime
 import os
 import logging
 
@@ -86,7 +84,7 @@ async def create_photos_zip(photos: List[Dict], session_id: str) -> io.BytesIO:
         with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zip_file:
             # Add session info file
             session_info = f"""QR Photo Session: {session_id}
-Generated on: {asyncio.get_event_loop().time()}
+Generated on: {datetime.utcnow().isoformat()}Z
 Total photos: {len(photos)}
 
 This ZIP file contains all photos uploaded to your QR Photo Session.
@@ -115,7 +113,7 @@ def create_empty_session_zip(session_id: str) -> io.BytesIO:
     
     with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zip_file:
         session_info = f"""QR Photo Session: {session_id}
-Generated on: {asyncio.get_event_loop().time()}
+Generated on: {datetime.utcnow().isoformat()}Z
 Total photos: 0
 
 This session currently has no photos uploaded.


### PR DESCRIPTION
## Summary
- replace usage of `asyncio.get_event_loop().time()` in ZIP metadata with real UTC timestamps
- ensure empty session ZIPs use the same user-friendly timestamp format
- remove unused imports left over from the previous approach

## Testing
- pytest *(fails: async tests require an additional plugin in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d42d7ff5e48329876274f63b7245d1