### PR TITLE
Improve GCP Terraform security defaults

### DIFF
--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -29,6 +29,15 @@ Değerler terraform.tfvars dosyalarinda girilmelidir. Varsayilan olmayan degiske
 | `github_repo` | Tetikleyici tarafindan izlenen repo adi | `qr-photo-app` |
 | `run_service_secret_values`* | Secret Manager'a yazilacak sirlar (istenirse bos map) | `{ "qr-photo-secret-key" = "..." }` |
 
+Yeni surumle birlikte GCP altyapisinda standart olarak VPC Flow Logs, Cloud NAT loglari ve firewall loglari acik gelir. GKE cluster
+API erisimi artik 0.0.0.0/0 yerine varsayilan olarak IAP IP araligi (35.235.240.0/20) ile sinirlanmistir. Bu davranislari
+degistirmek icin `infra/terraform/gcp/variables.tf` dosyasindaki asagidaki parametreleri override edebilirsiniz:
+
+- `enable_vpc_flow_logs`, `vpc_flow_logs_sampling`, `vpc_flow_logs_aggregation_interval`, `vpc_flow_logs_metadata`
+- `enable_nat_logging`, `nat_logging_filter`
+- `enable_firewall_logging`, `firewall_logging_metadata`, `firewall_internal_source_ranges`
+- `gke_master_authorized_networks`
+
 ### AWS
 
 | Değişken | Açıklama | Örnek |

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -36,7 +36,7 @@ degistirmek icin `infra/terraform/gcp/variables.tf` dosyasindaki asagidaki param
 - `enable_vpc_flow_logs`, `vpc_flow_logs_sampling`, `vpc_flow_logs_aggregation_interval`, `vpc_flow_logs_metadata`
 - `enable_nat_logging`, `nat_logging_filter`
 - `enable_firewall_logging`, `firewall_logging_metadata`, `firewall_internal_source_ranges`
-- `gke_master_authorized_networks`
+- `gke_master_authorized_networks` (veya geriye donuk uyumluluk icin `gke_master_authorized_range`)
 
 ### AWS
 

--- a/infra/terraform/gcp/main.tf
+++ b/infra/terraform/gcp/main.tf
@@ -117,7 +117,7 @@ module "workload_gke_cluster" {
   pods_secondary_range       = module.foundation_network.pods_secondary_range
   services_secondary_range   = module.foundation_network.services_secondary_range
   release_channel            = var.gke_release_channel
-  master_authorized_networks = local.gke_master_authorized_networks
+  master_authorized_network_cidrs = local.gke_master_authorized_networks
   master_authorized_range    = var.gke_master_authorized_range
 }
 

--- a/infra/terraform/gcp/main.tf
+++ b/infra/terraform/gcp/main.tf
@@ -48,6 +48,10 @@ locals {
   }, var.default_labels)
 
   internal_source_ranges = length(var.firewall_internal_source_ranges) > 0 ? var.firewall_internal_source_ranges : [var.vpc_subnet_cidr]
+
+  gke_master_authorized_networks = var.gke_master_authorized_networks != null ? var.gke_master_authorized_networks : (
+    var.gke_master_authorized_range != null ? [var.gke_master_authorized_range] : null
+  )
 }
 
 # Foundation: VPC ve subnet yapisi.
@@ -113,7 +117,8 @@ module "workload_gke_cluster" {
   pods_secondary_range       = module.foundation_network.pods_secondary_range
   services_secondary_range   = module.foundation_network.services_secondary_range
   release_channel            = var.gke_release_channel
-  master_authorized_networks = var.gke_master_authorized_networks
+  master_authorized_networks = local.gke_master_authorized_networks
+  master_authorized_range    = var.gke_master_authorized_range
 }
 
 data "google_client_config" "default" {}

--- a/infra/terraform/gcp/modules/foundation/network/main.tf
+++ b/infra/terraform/gcp/modules/foundation/network/main.tf
@@ -39,6 +39,15 @@ resource "google_compute_subnetwork" "public" {
     range_name    = "${local.effective_prefix}-services"
     ip_cidr_range = var.secondary_range_services
   }
+
+  dynamic "log_config" {
+    for_each = var.enable_flow_logs ? [1] : []
+    content {
+      aggregation_interval = var.flow_logs_aggregation_interval
+      flow_sampling        = var.flow_logs_sampling
+      metadata             = var.flow_logs_metadata
+    }
+  }
 }
 
 # Cloud Router olusturarak NAT icin temel saglar.
@@ -63,6 +72,11 @@ resource "google_compute_router_nat" "main" {
   enable_endpoint_independent_mapping = true
 
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = var.enable_nat_logging
+    filter = var.nat_logging_filter
+  }
 }
 
 

--- a/infra/terraform/gcp/modules/foundation/network/outputs.tf
+++ b/infra/terraform/gcp/modules/foundation/network/outputs.tf
@@ -29,3 +29,9 @@ output "nat_name" {
   description = "Cloud NAT adi"
   value       = google_compute_router_nat.main.name
 }
+
+# Subnetin ana CIDR blogu.
+output "subnet_cidr_range" {
+  description = "Subnet icin ana CIDR"
+  value       = var.subnet_cidr_range
+}

--- a/infra/terraform/gcp/modules/foundation/network/variables.tf
+++ b/infra/terraform/gcp/modules/foundation/network/variables.tf
@@ -42,3 +42,45 @@ variable "secondary_range_services" {
   description = "Servis IP atamalari icin ikinci CIDR"
   type        = string
 }
+
+# VPC Flow Logs ozelligi.
+variable "enable_flow_logs" {
+  description = "Subnet icin flow loglarini etkinlestir"
+  type        = bool
+  default     = true
+}
+
+# Flow Logs toplama araligi.
+variable "flow_logs_aggregation_interval" {
+  description = "Flow Logs toplama araligi"
+  type        = string
+  default     = "INTERVAL_10_MIN"
+}
+
+# Flow Logs ornekleme oranini belirler.
+variable "flow_logs_sampling" {
+  description = "Flow Logs ornekleme orani"
+  type        = number
+  default     = 0.5
+}
+
+# Flow Logs metadata modunu tanimlar.
+variable "flow_logs_metadata" {
+  description = "Flow Logs metadata modu"
+  type        = string
+  default     = "INCLUDE_ALL_METADATA"
+}
+
+# Cloud NAT loglama ozelligi.
+variable "enable_nat_logging" {
+  description = "Cloud NAT loglarini etkinlestir"
+  type        = bool
+  default     = true
+}
+
+# Cloud NAT log filtresi.
+variable "nat_logging_filter" {
+  description = "Cloud NAT log filtresi"
+  type        = string
+  default     = "ALL"
+}

--- a/infra/terraform/gcp/modules/foundation/security/variables.tf
+++ b/infra/terraform/gcp/modules/foundation/security/variables.tf
@@ -24,3 +24,24 @@ variable "network_id" {
   description = "VPC kaynak kimligi"
   type        = string
 }
+
+# Internal firewall icin izin verilecek CIDR listesi.
+variable "internal_source_ranges" {
+  description = "Internal firewall kurali icin izinli CIDR listesi"
+  type        = list(string)
+  default     = []
+}
+
+# Firewall loglarini etkinlestir.
+variable "enable_firewall_logging" {
+  description = "Firewall loglarini etkinlestir"
+  type        = bool
+  default     = true
+}
+
+# Firewall log metadata modu.
+variable "firewall_logging_metadata" {
+  description = "Firewall log metadata modu"
+  type        = string
+  default     = "INCLUDE_ALL_METADATA"
+}

--- a/infra/terraform/gcp/modules/platform/ci_cd/main.tf
+++ b/infra/terraform/gcp/modules/platform/ci_cd/main.tf
@@ -25,7 +25,7 @@ resource "google_cloudbuild_trigger" "github" {
 
   included_files = var.included_files
   ignored_files  = var.ignored_files
-  substitutions = var.substitutions
+  substitutions  = var.substitutions
 
   service_account = "projects/${var.project_id}/serviceAccounts/305617730642-compute@developer.gserviceaccount.com"
 

--- a/infra/terraform/gcp/modules/workload/gke_cluster/main.tf
+++ b/infra/terraform/gcp/modules/workload/gke_cluster/main.tf
@@ -39,10 +39,16 @@ resource "google_container_cluster" "main" {
     enabled = true
   }
 
-  master_authorized_networks_config {
-    cidr_blocks {
-      display_name = "admin"
-      cidr_block   = var.master_authorized_range
+  dynamic "master_authorized_networks_config" {
+    for_each = length(var.master_authorized_networks) > 0 ? [1] : []
+    content {
+      dynamic "cidr_blocks" {
+        for_each = { for idx, cidr in var.master_authorized_networks : idx => cidr }
+        content {
+          display_name = "admin-${cidr_blocks.key}"
+          cidr_block   = cidr_blocks.value
+        }
+      }
     }
   }
 

--- a/infra/terraform/gcp/modules/workload/gke_cluster/main.tf
+++ b/infra/terraform/gcp/modules/workload/gke_cluster/main.tf
@@ -20,7 +20,8 @@ resource "google_project_service" "required" {
 locals {
   default_admin_cidr = "35.235.240.0/20"
 
-  effective_master_authorized_networks = (
+  effective_master_authorized_cidrs = (
+    var.master_authorized_network_cidrs != null ? var.master_authorized_network_cidrs :
     var.master_authorized_networks != null ? var.master_authorized_networks :
     var.master_authorized_range != null ? [var.master_authorized_range] :
     [local.default_admin_cidr]
@@ -50,10 +51,10 @@ resource "google_container_cluster" "main" {
   }
 
   dynamic "master_authorized_networks_config" {
-    for_each = length(local.effective_master_authorized_networks) > 0 ? [1] : []
+    for_each = length(local.effective_master_authorized_cidrs) > 0 ? [1] : []
     content {
       dynamic "cidr_blocks" {
-        for_each = { for idx, cidr in local.effective_master_authorized_networks : idx => cidr }
+        for_each = { for idx, cidr in local.effective_master_authorized_cidrs : idx => cidr }
         content {
           display_name = "admin-${cidr_blocks.key}"
           cidr_block   = cidr_blocks.value

--- a/infra/terraform/gcp/modules/workload/gke_cluster/variables.tf
+++ b/infra/terraform/gcp/modules/workload/gke_cluster/variables.tf
@@ -57,8 +57,16 @@ variable "master_authorized_range" {
   nullable    = true
 }
 
-# Master yetkili aglar icin CIDR listesi.
+# [DEPRECATED] Onceki surumle uyum icin master CIDR listesi degiskeni.
 variable "master_authorized_networks" {
+  description = "[DEPRECATED] Master API erisimi icin yetkili CIDR listesi"
+  type        = list(string)
+  default     = null
+  nullable    = true
+}
+
+# Master yetkili aglar icin yeni CIDR listesi girdisi.
+variable "master_authorized_network_cidrs" {
   description = "Master API erisimi icin yetkili CIDR listesi"
   type        = list(string)
   default     = null

--- a/infra/terraform/gcp/modules/workload/gke_cluster/variables.tf
+++ b/infra/terraform/gcp/modules/workload/gke_cluster/variables.tf
@@ -49,9 +49,18 @@ variable "release_channel" {
   default     = "REGULAR"
 }
 
+# GERİYE DONUK UYUMLULUK: Tek bir CIDR icin eski degisken.
+variable "master_authorized_range" {
+  description = "[DEPRECATED] Master API erisimi icin tek CIDR"
+  type        = string
+  default     = null
+  nullable    = true
+}
+
 # Master yetkili aglar icin CIDR listesi.
 variable "master_authorized_networks" {
   description = "Master API erisimi icin yetkili CIDR listesi"
   type        = list(string)
-  default     = ["35.235.240.0/20"]
+  default     = null
+  nullable    = true
 }

--- a/infra/terraform/gcp/modules/workload/gke_cluster/variables.tf
+++ b/infra/terraform/gcp/modules/workload/gke_cluster/variables.tf
@@ -49,9 +49,9 @@ variable "release_channel" {
   default     = "REGULAR"
 }
 
-# Master yetkili aglar icin CIDR tanimi.
-variable "master_authorized_range" {
-  description = "Master API erisimi icin yetkili CIDR"
-  type        = string
-  default     = "0.0.0.0/0"
+# Master yetkili aglar icin CIDR listesi.
+variable "master_authorized_networks" {
+  description = "Master API erisimi icin yetkili CIDR listesi"
+  type        = list(string)
+  default     = ["35.235.240.0/20"]
 }

--- a/infra/terraform/gcp/modules/workload/gke_workload/main.tf
+++ b/infra/terraform/gcp/modules/workload/gke_workload/main.tf
@@ -103,7 +103,7 @@ resource "kubernetes_service" "this" {
   metadata {
     name      = "${var.name_prefix}-service"
     namespace = kubernetes_namespace.this.metadata[0].name
-    labels    = merge(var.labels, {
+    labels = merge(var.labels, {
       app = var.name_prefix
     })
   }

--- a/infra/terraform/gcp/terraform.tfvars.example
+++ b/infra/terraform/gcp/terraform.tfvars.example
@@ -14,8 +14,18 @@ vpc_subnet_cidr         = "10.20.0.0/24"
 vpc_secondary_pods      = "10.21.0.0/20"
 vpc_secondary_services  = "10.22.0.0/24"
 
-gke_release_channel        = "REGULAR"
-gke_master_authorized_range = "192.168.0.0/24"
+gke_release_channel             = "REGULAR"
+gke_master_authorized_networks  = ["192.168.0.0/24"]
+firewall_internal_source_ranges = ["192.168.0.0/24"]
+
+enable_vpc_flow_logs                = true
+vpc_flow_logs_sampling              = 0.5
+vpc_flow_logs_aggregation_interval  = "INTERVAL_10_MIN"
+vpc_flow_logs_metadata              = "INCLUDE_ALL_METADATA"
+enable_nat_logging                  = true
+nat_logging_filter                  = "ALL"
+enable_firewall_logging             = true
+firewall_logging_metadata           = "INCLUDE_ALL_METADATA"
 
 artifact_location     = "europe"
 artifact_repository_id = "qr-photo-backend"

--- a/infra/terraform/gcp/terraform.tfvars.example
+++ b/infra/terraform/gcp/terraform.tfvars.example
@@ -14,8 +14,11 @@ vpc_subnet_cidr         = "10.20.0.0/24"
 vpc_secondary_pods      = "10.21.0.0/20"
 vpc_secondary_services  = "10.22.0.0/24"
 
+# GKE master API erisimi icin birden fazla CIDR tanimlayabilirsiniz.
 gke_release_channel             = "REGULAR"
 gke_master_authorized_networks  = ["192.168.0.0/24"]
+# Tek bir CIDR kullanmak isterseniz asagidaki eski degiskeni tercih edebilirsiniz.
+# gke_master_authorized_range      = "192.168.0.0/24"
 firewall_internal_source_ranges = ["192.168.0.0/24"]
 
 enable_vpc_flow_logs                = true

--- a/infra/terraform/gcp/variables.tf
+++ b/infra/terraform/gcp/variables.tf
@@ -64,11 +64,20 @@ variable "gke_release_channel" {
   default     = "REGULAR"
 }
 
+# GERİYE DONUK UYUMLULUK: Tek bir CIDR icin eski degisken.
+variable "gke_master_authorized_range" {
+  description = "[DEPRECATED] GKE master erisimi icin tek CIDR"
+  type        = string
+  default     = null
+  nullable    = true
+}
+
 # Master API erisimine izin verilen CIDR listesi.
 variable "gke_master_authorized_networks" {
   description = "GKE master erisimi icin yetkili CIDR listesi"
   type        = list(string)
-  default     = ["35.235.240.0/20"]
+  default     = null
+  nullable    = true
 }
 
 # VPC Flow Logs icin aktivasyon.

--- a/infra/terraform/gcp/variables.tf
+++ b/infra/terraform/gcp/variables.tf
@@ -64,11 +64,74 @@ variable "gke_release_channel" {
   default     = "REGULAR"
 }
 
-# Master API erisimine izin verilen CIDR araligi.
-variable "gke_master_authorized_range" {
-  description = "GKE master erisim CIDR"
+# Master API erisimine izin verilen CIDR listesi.
+variable "gke_master_authorized_networks" {
+  description = "GKE master erisimi icin yetkili CIDR listesi"
+  type        = list(string)
+  default     = ["35.235.240.0/20"]
+}
+
+# VPC Flow Logs icin aktivasyon.
+variable "enable_vpc_flow_logs" {
+  description = "VPC Flow Logs ozelligini ac/kapa"
+  type        = bool
+  default     = true
+}
+
+# VPC Flow Logs icin toplama araligi.
+variable "vpc_flow_logs_aggregation_interval" {
+  description = "VPC Flow Logs toplama araligi"
   type        = string
-  default     = "0.0.0.0/0"
+  default     = "INTERVAL_10_MIN"
+}
+
+# VPC Flow Logs icin ornekleme orani.
+variable "vpc_flow_logs_sampling" {
+  description = "VPC Flow Logs ornekleme orani"
+  type        = number
+  default     = 0.5
+}
+
+# VPC Flow Logs icin metadata secimi.
+variable "vpc_flow_logs_metadata" {
+  description = "VPC Flow Logs metadata modu"
+  type        = string
+  default     = "INCLUDE_ALL_METADATA"
+}
+
+# Cloud NAT loglama ozelligi.
+variable "enable_nat_logging" {
+  description = "Cloud NAT loglarini etkinlestir"
+  type        = bool
+  default     = true
+}
+
+# Cloud NAT log filtresi.
+variable "nat_logging_filter" {
+  description = "Cloud NAT log filtresi"
+  type        = string
+  default     = "ALL"
+}
+
+# Firewall loglarini ac/kapa.
+variable "enable_firewall_logging" {
+  description = "Firewall loglarini etkinlestir"
+  type        = bool
+  default     = true
+}
+
+# Firewall loglari metadata modu.
+variable "firewall_logging_metadata" {
+  description = "Firewall log metadata modu"
+  type        = string
+  default     = "INCLUDE_ALL_METADATA"
+}
+
+# Internal firewall icin izin verilecek CIDR listesi.
+variable "firewall_internal_source_ranges" {
+  description = "Internal firewall kurali icin CIDR listesi"
+  type        = list(string)
+  default     = []
 }
 
 # Artifact Registry lokasyonu.


### PR DESCRIPTION
## Summary
- enable configurable VPC flow logs and Cloud NAT logging on the shared network module
- tighten firewall defaults with scoped source ranges, logging and prefixed resource names
- require explicit GKE master authorized networks and document the new security-focused variables

## Testing
- terraform fmt -recursive infra/terraform/gcp
- terraform -chdir=infra/terraform/gcp validate

------
https://chatgpt.com/codex/tasks/task_e_68d4384cd34483299ad6a51747230aa4